### PR TITLE
feat: add highest severity selection for vulnerability deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A self-installing Python script for aggregating and deduplicating Grype vulnerab
 - **SBOM Auto-Scan**: Automatically detects and scans Syft SBOM files with Grype
 - **Auto-Conversion**: Automatically converts Grype reports to CycloneDX format for Trivy scanning
 - **CVE Deduplication**: Combines identical vulnerabilities across multiple scans
+- **Automatic Null CVSS Filtering**: Filters out invalid CVSS scores (null, N/A, or zero) from all vulnerability reports by default
+- **CVSS 3.x-Based Severity Selection**: Optional mode to select highest severity based on actual CVSS 3.x base scores, not just severity labels
 - **Occurrence Tracking**: Counts how many times each CVE appears
 - **Zero Config**: Dependencies (Rich, Pydantic) automatically installed via uv
 - **Flexible CLI**: argparse-based interface with sensible defaults
@@ -107,15 +109,33 @@ cve-report-aggregator -v
 cve-report-aggregator -i ./scans -o ./results/unified.json --scanner trivy -v
 ```
 
+### Use Highest Severity Across Scanners
+
+When scanning with multiple scanners (or multiple runs of the same scanner), automatically select the highest severity rating:
+
+```bash
+# Scan the same image with both Grype and Trivy, use highest severity
+grype myapp:latest -o json > reports/grype-app.json
+trivy image myapp:latest -f json -o reports/trivy-app.json
+cve-report-aggregator -i reports/ --use-highest-severity -o unified.json
+```
+
+This is particularly useful when:
+
+- Combining results from multiple scanners with different severity assessments
+- Ensuring conservative (worst-case) severity ratings for compliance
+- Aggregating multiple scans over time where severity data may have been updated
+
 ## Command-Line Options
 
-| Option | Short | Description | Default |
-|--------|-------|-------------|---------|
-| `--input-dir` | `-i` | Input directory containing scan reports or SBOMs | `./reports` |
-| `--output-file` | `-o` | Output file path for unified report | `./unified-report.json` |
-| `--scanner` | `-s` | Scanner type to process (`grype` or `trivy`) | `grype` |
-| `--verbose` | `-v` | Enable verbose output with detailed processing | `false` |
-| `--help` | `-h` | Show help message and exit | N/A |
+| Option                   | Short | Description                                                                   | Default                 |
+| ------------------------ | ----- | ----------------------------------------------------------------------------- | ----------------------- |
+| `--input-dir`            | `-i`  | Input directory containing scan reports or SBOMs                              | `./reports`             |
+| `--output-file`          | `-o`  | Output file path for unified report                                           | `./unified-report.json` |
+| `--scanner`              | `-s`  | Scanner type to process (`grype` or `trivy`)                                  | `grype`                 |
+| `--verbose`              | `-v`  | Enable verbose output with detailed processing                                | `false`                 |
+| `--use-highest-severity` | -     | Use highest severity rating across all scanner reports for each vulnerability | `false`                 |
+| `--help`                 | `-h`  | Show help message and exit                                                    | N/A                     |
 
 ## Output Format
 
@@ -155,9 +175,9 @@ The aggregation script implements intelligent deduplication of vulnerabilities a
 The deduplication process consolidates identical vulnerabilities found across multiple container images and packages, tracking:
 
 1. **Occurrence counting** - How many times each vulnerability appears
-2. **Source tracking** - Which images/packages are affected
-3. **CVE normalization** - Preferring CVE IDs over GHSA IDs for consistency
-4. **Data aggregation** - Merging vulnerability details while preserving context
+1. **Source tracking** - Which images/packages are affected
+1. **CVE normalization** - Preferring CVE IDs over GHSA IDs for consistency
+1. **Data aggregation** - Merging vulnerability details while preserving context
 
 ### High-Level Workflow
 
@@ -263,10 +283,19 @@ sequenceDiagram
 **Why CVE IDs are preferred:**
 
 1. **Universal Standard**: CVE (Common Vulnerabilities and Exposures) is the industry standard identifier maintained by MITRE and recognized globally
-2. **Consistency Across Scanners**: Different scanners may use different internal IDs (GHSA, RUSTSEC, etc.), but CVE IDs provide a common reference
-3. **Better Deduplication**: The same vulnerability might be reported as `GHSA-xxxx-yyyy-zzzz` by GitHub Security Advisory and `CVE-2024-12345` by another source
-4. **Trivia Native Format**: Trivy reports already use CVE IDs natively, avoiding conversion complexity
-5. **Cross-Reference Capability**: CVE IDs are more widely used in vulnerability databases, SBOMs, and security tools
+1. **Consistency Across Scanners**: Different scanners may use different internal IDs (GHSA, RUSTSEC, etc.), but CVE IDs provide a common reference
+1. **Better Deduplication**: The same vulnerability might be reported as `GHSA-xxxx-yyyy-zzzz` by GitHub Security Advisory and `CVE-2024-12345` by another source
+1. **Trivia Native Format**: Trivy reports already use CVE IDs natively, avoiding conversion complexity
+1. **Cross-Reference Capability**: CVE IDs are more widely used in vulnerability databases, SBOMs, and security tools
+
+> [!NOTE]
+> **About Grype's `relatedVulnerabilities` field:**
+>
+> The `relatedVulnerabilities` array in Grype's JSON output contains cross-references to related vulnerability identifiers from different vulnerability databases. For example, when Grype matches a GitHub Security Advisory (GHSA-xxxx-yyyy-zzzz), the `relatedVulnerabilities` field may include the corresponding CVE ID from the National Vulnerability Database (NVD), along with other related identifiers from distribution-specific advisories.
+>
+> Each entry includes the vulnerability `id`, `dataSource` URL, `namespace`, and `severity`. This allows the script to normalize vulnerability identifiers by preferring authoritative CVE IDs over database-specific identifiers.
+>
+> **Documentation:** While there is no comprehensive formal schema documentation for Grype's JSON output yet (tracked in [GitHub Issue #2212](https://github.com/anchore/grype/issues/2212)), you can reference the [Go package documentation](https://pkg.go.dev/github.com/anchore/grype/grype/presenter/models) or examine sample JSON output from `grype <image> -o json` to understand the data structure.
 
 **Implementation Strategy:**
 
@@ -336,13 +365,13 @@ This enables:
 
 The aggregation strategy balances completeness with efficiency:
 
-| Data Type | Strategy | Rationale |
-|-----------|----------|-----------|
-| **Count** | Sum all occurrences | Need total impact across all images |
-| **Affected Sources** | Collect all instances | Critical for remediation planning |
-| **Vulnerability Data** | Store first occurrence only | Core vulnerability details are identical |
-| **Related Vulnerabilities** | Store first occurrence only | Cross-references don't change |
-| **Match Details** | Collect unique entries | Different matchers may provide different insights |
+| Data Type                   | Strategy                    | Rationale                                         |
+| --------------------------- | --------------------------- | ------------------------------------------------- |
+| **Count**                   | Sum all occurrences         | Need total impact across all images               |
+| **Affected Sources**        | Collect all instances       | Critical for remediation planning                 |
+| **Vulnerability Data**      | Store first occurrence only | Core vulnerability details are identical          |
+| **Related Vulnerabilities** | Store first occurrence only | Cross-references don't change                     |
+| **Match Details**           | Collect unique entries      | Different matchers may provide different insights |
 
 **First Occurrence Only:**
 
@@ -447,17 +476,566 @@ vuln_map = {
 The deduplication process is optimized for:
 
 1. **Memory Efficiency**: Using `defaultdict` to avoid repeated key existence checks
-2. **Linear Complexity**: Single pass through all reports, O(n) where n = total vulnerabilities
-3. **Hash-Based Lookups**: Dictionary-based vulnerability tracking for O(1) access
-4. **Minimal Data Duplication**: Storing full vulnerability data only once per unique CVE
+1. **Linear Complexity**: Single pass through all reports, O(n) where n = total vulnerabilities
+1. **Hash-Based Lookups**: Dictionary-based vulnerability tracking for O(1) access
+1. **Minimal Data Duplication**: Storing full vulnerability data only once per unique CVE
 
 ### Edge Cases Handled
 
 1. **Missing CVE IDs**: Falls back to GHSA or original vulnerability ID
-2. **Empty Related Vulnerabilities**: Gracefully handles reports without CVE cross-references
-3. **Multiple CVE IDs**: Uses the first CVE found in `relatedVulnerabilities`
-4. **Duplicate Match Details**: Deduplicates match details while preserving unique entries
-5. **Scanner Format Differences**: Normalizes Trivy data to Grype-like structure for consistency
+1. **Empty Related Vulnerabilities**: Gracefully handles reports without CVE cross-references
+1. **Multiple CVE IDs**: Uses the first CVE found in `relatedVulnerabilities`
+1. **Duplicate Match Details**: Deduplicates match details while preserving unique entries
+1. **Scanner Format Differences**: Normalizes Trivy data to Grype-like structure for consistency
+1. **Null/Invalid CVSS Scores**: Automatically filters out null, N/A, or zero CVSS scores from all reports
+
+### CVSS Score Filtering
+
+The script automatically filters out invalid CVSS scores from vulnerability data in **all modes** (both default and `--use-highest-severity`). This ensures that only valid, actionable CVSS scores are included in the unified report.
+
+#### What Gets Filtered
+
+CVSS entries are removed if their `baseScore` is:
+
+- `null` or `N/A` (no score available)
+- `0` or `0.0` (invalid score)
+
+#### Why This Matters
+
+Some vulnerability sources may not have CVSS scores available for certain CVEs:
+
+**Real-World Example: CVE-2025-61772**
+
+```
+Scanner Report A:
+├─ NIST (Primary):     baseScore: null    ❌ Filtered out
+└─ GitHub CNA (Secondary): baseScore: 7.5     ✓ Kept
+
+Scanner Report B:
+└─ RedHat (Secondary): baseScore: 8.2      ✓ Kept
+
+Result with --use-highest-severity: Selects 8.2 (highest valid score)
+Result without flag: Selects 7.5 (first valid score, alphabetically)
+```
+
+Without filtering, the unified report would include CVSS entries with `null` scores, which:
+
+- Cannot be used for risk assessment
+- Break CVSS-based comparisons
+- Clutter the vulnerability data with unusable information
+
+#### Implementation Details
+
+The filtering is applied automatically during vulnerability data processing for both Grype and Trivy formats:
+
+**Grype Format:**
+
+```python
+# Filters CVSS array entries
+{
+  "cvss": [
+    {"type": "Primary", "version": "3.1", "metrics": {"baseScore": null}},   # Removed
+    {"type": "Secondary", "version": "3.1", "metrics": {"baseScore": 7.5}}   # Kept
+  ]
+}
+```
+
+**Trivy Format:**
+
+```python
+# Filters CVSS dictionary entries by vendor
+{
+  "cvss": {
+    "nvd": {"V3Score": null, "V3Vector": "..."},      # Removed
+    "ghsa": {"V3Score": 7.5, "V3Vector": "..."}       # Kept
+  }
+}
+```
+
+#### Benefits
+
+1. **Cleaner Reports**: Only valid CVSS scores appear in the unified report
+1. **Accurate Comparisons**: The `--use-highest-severity` mode compares only valid scores
+1. **Better Risk Assessment**: Focus on vulnerabilities with actionable CVSS data
+1. **Consistent Behavior**: Filtering applies to all scanners and all modes
+
+### Severity Source Handling: Grype vs Trivy
+
+Both scanners aggregate vulnerability data from multiple sources, but they handle severity prioritization differently:
+
+#### Trivy: Explicit Severity Source Priority
+
+Trivy provides **user-configurable** priority ordering for vulnerability severity data sources via the `--vuln-severity-source` flag:
+
+```bash
+# Example: Prioritize RedHat advisories over NVD
+trivy sbom --vuln-severity-source redhat,nvd <sbom-file>
+```
+
+**Available sources** (28+ options):
+
+- `nvd`, `redhat`, `redhat-oval`, `debian`, `ubuntu`, `alpine`,
+- `ghsa`, `osv`, `ruby-advisory-db`, `nodejs-security-wg`
+- Distribution-specific: `oracle-oval`, `suse-cvrf`, `photon`, `alma`, `rocky`, `wolfi`, `chainguard`
+- Cloud providers: `amazon`, `azure`
+- Language ecosystems: `php-security-advisories`, `govulndb`
+- Default: `auto` (lets Trivy decide based on package type)
+
+This allows users to explicitly control which data source's severity rating is used when multiple sources provide conflicting severity assessments.
+
+#### Grype: Implicit Namespace-Based Priority
+
+Grype does **not currently provide** a user-configurable severity source priority mechanism. Instead, severity is determined by:
+
+1. **Namespace Matching**: Severity is automatically selected based on which namespace (data source) matches the package:
+
+   - Ubuntu packages -> Ubuntu security advisories
+   - Debian packages -> Debian CVE tracker
+   - Python packages -> GitHub Security Advisories (GHSA)
+   - Fallback to NVD when vendor-specific data is unavailable
+
+1. **Vendor Data Prioritization**: Grype implicitly prioritizes **vendor-specific advisories** over NVD data because vendors evaluate severity based on their compile options, configurations, and distribution methods.
+
+1. **Multiple Sources**: Grype's database aggregates data from:
+
+   - Alpine Linux SecDB, Amazon Linux ALAS, RedHat RHSAs
+   - Debian Linux CVE Tracker, Ubuntu Linux Security
+   - GitHub Security Advisories (GHSA), Oracle Linux OVAL
+   - National Vulnerability Database (NVD) as fallback
+   - Wolfi SecDB and other specialized sources
+
+1. **Severity Ranking**: Grype uses an internal "Rank" field in its database schema v6 for severity comparison, but this is not user-configurable.
+
+**Example of namespace-based differences:**
+
+The same CVE may have different severity ratings:
+
+- `CVE-2024-12345` in Ubuntu namespace: **Medium**
+- `CVE-2024-12345` in NVD namespace: **High**
+- Grype will use the Ubuntu severity when scanning Ubuntu packages
+
+#### Key Differences Summary
+
+| Feature                     | Trivy                                       | Grype                               |
+| --------------------------- | ------------------------------------------- | ----------------------------------- |
+| **Severity Source Control** | Explicit via `--vuln-severity-source` flag  | Implicit via namespace matching     |
+| **User Configuration**      | 28+ configurable sources                    | Not user-configurable               |
+| **Priority Method**         | User-defined ordered list                   | Automatic (vendor > NVD)            |
+| **Consistency**             | Same severity across scans with same config | May vary based on package namespace |
+| **Flexibility**             | High - full control over source priority    | Low - determined by package type    |
+
+#### Recommendations
+
+**When to use Trivy:**
+
+- You need explicit control over severity source priority
+- Your organization has a policy requiring specific data sources (e.g., RedHat advisories for RHEL systems)
+- You want consistent severity ratings across different package types
+
+**When to use Grype:**
+
+- You trust vendor-specific severity assessments for their own packages
+- You want automatic prioritization based on package ecosystem
+- You prefer namespace-aware severity selection
+
+**For this aggregation script:**
+
+- The script accepts reports from either scanner without modification
+- Severity data is preserved as-is from the scanner's output
+- For post-processing severity adjustments, consider using Trivy with `--vuln-severity-source` during initial scanning
+
+> [!IMPORTANT]
+> **How This Script Handles Scanner Differences:**
+>
+> The `cve-report-aggregator.py` script is **scanner-agnostic** and provides two modes for handling severity data across multiple reports:
+>
+> **Default Mode (First-Occurrence)**:
+>
+> 1. **Preserves Original Severity**: When processing reports, the script stores severity data **exactly as reported** by each scanner:
+>
+>    ```python
+>    # From cve-report-aggregator.py:602-603
+>    if vuln_entry["vulnerability_data"] is None:
+>        vuln_entry["vulnerability_data"] = match["vulnerability"]  # Grype format preserved
+>    ```
+>
+> 1. **No Severity Normalization**: The script does NOT attempt to reconcile different severity ratings from different scanners. If you scan the same image with both Grype and Trivy:
+>
+>    - Each scanner's findings are stored separately
+>    - If both find the same CVE with different severities, **both entries are preserved**
+>    - The `count` field tracks how many times the CVE appears across all reports
+>
+> 1. **Scanner Identification**: Each vulnerability entry includes source tracking:
+>
+>    ```json
+>    {
+>      "vulnerability_id": "CVE-2024-12345",
+>      "count": 2,
+>      "affected_sources": [
+>        {
+>          "source_file": "grype-scan.json",
+>          "image": "myapp:latest",
+>          "artifact": {"name": "openssl", "version": "1.1.1k"}
+>        },
+>        {
+>          "source_file": "trivy-scan.json",
+>          "image": "myapp:latest",
+>          "artifact": {"name": "openssl", "version": "1.1.1k"}
+>        }
+>      ],
+>      "vulnerability": {
+>        "severity": "High"  // From first occurrence (Grype in this example)
+>      }
+>    }
+>    ```
+>
+> 1. **First-Occurrence Rule**: The script uses severity from the **first occurrence** of a vulnerability:
+>
+>    - If Grype report is processed first: Uses Grype's severity
+>    - If Trivy report is processed first: Uses Trivy's severity
+>    - File processing order is alphabetical by filename
+>
+> 1. **No Scanner-Specific Logic**: The deduplication algorithm treats all reports equally:
+>
+>    ```python
+>    # From cve-report-aggregator.py:578
+>    primary_id = cve_ids[0] if cve_ids else vuln_id  # CVE normalization only
+>    ```
+>
+>    The only "normalization" is preferring CVE IDs over GHSA IDs for the primary key—severity data remains untouched.
+>
+> **Implications:**
+>
+> - **Same CVE, different severity**: Only the first scanner's severity appears in the unified report
+> - **Cross-scanner comparison**: Use the `affected_sources` array to see which scanners found which vulnerabilities
+> - **Severity consistency**: If you need consistent severity ratings, scan with only one scanner or always process reports in the same order
+> - **Post-processing**: You can post-process the unified report to override severities based on your organization's preferred data source
+>
+> **Example Scenarios:**
+>
+> | Scan Order  | Files Processed                    | CVE-2024-12345 Severity in Output |
+> | ----------- | ---------------------------------- | --------------------------------- |
+> | Grype first | `grype-app.json`, `trivy-app.json` | Grype's severity (e.g., "Medium") |
+> | Trivy first | `trivy-app.json`, `grype-app.json` | Trivy's severity (e.g., "High")   |
+> | Only Grype  | `grype-app.json`                   | Grype's severity                  |
+> | Only Trivy  | `trivy-app.json`                   | Trivy's severity                  |
+>
+> **Highest-Severity Mode (Optional)**:
+>
+> When the `--use-highest-severity` flag is enabled, the script automatically selects the **highest severity rating** across all scanner reports for each vulnerability using **CVSS 3.x base scores**:
+>
+> ```bash
+> cve-report-aggregator --use-highest-severity -i reports/ -o unified.json
+> ```
+>
+> **Selection Methodology:**
+>
+> 1. **Null Score Filtering (Pre-processing)**: Automatically filters out null, N/A, or zero CVSS scores before comparison
+>
+>    - Ensures only valid scores participate in severity selection
+>    - Applied to both Grype and Trivy report formats
+>
+> 1. **CVSS 3.x Score Comparison (Primary)**: Compares actual CVSS 3.x base scores numerically
+>
+>    - Example: Score 8.9 > 7.5, even if both are labeled "High"
+>    - Handles multiple CVSS sources (NIST, CNA, vendor-specific)
+>    - Automatically selects the highest score when a CVE has multiple assessments
+>
+> 1. **Severity String Fallback (Secondary)**: If no CVSS 3.x scores are available
+>
+>    - Uses severity string ranking: **Critical > High > Medium > Low > Negligible > Unknown**
+>
+> **Real-World Example: CVE-2025-61772**
+>
+> ```
+> Scanner Report A:
+> ├─ NIST (Primary) CVSS 3.1: null       ❌ Filtered out (null score)
+> └─ CNA (GitHub) CVSS 3.1: 7.5 → HIGH   ✓ Kept (valid score)
+>
+> Scanner Report B:
+> └─ Vendor (RedHat) CVSS 3.1: 8.2 → HIGH ✓ Kept (valid score)
+>
+> Result: Selects Report B (8.2 > 7.5)
+> Note: Null NIST score automatically filtered before comparison
+> ```
+>
+> - **Null scores are automatically filtered** before comparison
+> - Ensures conservative (worst-case) severity ratings based on actual scores
+> - Useful for compliance requirements that mandate highest severity
+> - Works across both Grype and Trivy reports
+> - Prefers CVSS 3.x over CVSS 2.0 or missing scores
+>
+> **Recommendation**:
+>
+> - **Use `--use-highest-severity`** when:
+>
+>   - Combining results from multiple scanners with different severity assessments
+>   - Compliance or audit requirements mandate conservative severity ratings
+>   - You want worst-case severity for risk assessment
+>
+> - **Use default mode** when:
+>
+>   - You trust a specific scanner's severity assessment
+>   - You want to preserve the exact findings from one primary scanner
+>   - Using consistent filename prefixes: `grype-*.json` and `trivy-*.json` to control processing order
+
+#### References
+
+- **Grype severity handling**: [GitHub Issue #717](https://github.com/anchore/grype/issues/717), [Issue #1312](https://github.com/anchore/grype/issues/1312)
+- **Trivy data sources**: Run `trivy sbom --help` and search for `--vuln-severity-source`
+- **Vendor vs NVD severity discussion**: [Trivy Discussion #3395](https://github.com/aquasecurity/trivy/discussions/3395)
+
+## Using Grype and Trivy Together: Best Practices
+
+### Why Different Results Are Expected (and Valuable)
+
+Grype and Trivy will produce **different results by design**, and this is actually beneficial for comprehensive security analysis. Understanding why they differ helps you make better remediation decisions.
+
+#### Key Philosophical Differences
+
+| Aspect                | Grype                                      | Trivy                                           |
+| --------------------- | ------------------------------------------ | ----------------------------------------------- |
+| **Matching Strategy** | Ecosystem-aware (reduces false positives)  | Comprehensive CPE matching (broader coverage)   |
+| **Default Priority**  | Namespace-based (automatic)                | Vendor-preferred with `auto` (configurable)     |
+| **Primary Use Case**  | Ecosystem-specific vulnerability detection | Compliance and comprehensive scanning           |
+| **Data Sources**      | GHSA, distro-specific feeds, NVD           | 28+ sources including vendor-specific databases |
+
+### Should You Try to Align Them?
+
+**Short answer: No.** Here's why:
+
+1. **Different tools, different strengths**: Forcing one to behave like the other negates its unique advantages
+1. **Compliance requirements**: Many enterprises require NVD severity ratings; using vendor-specific ratings may conflict with policy
+1. **Context matters**: Ubuntu's "Medium" vs NVD's "High" for the same CVE can both be correct depending on configuration
+1. **Your script already handles both**: The aggregation tool preserves data from each scanner without modification
+
+**Exception:** Only attempt alignment if:
+
+- Your security team has mandated specific data source priority
+- Regulatory compliance requires specific sources (e.g., RedHat advisories for RHEL)
+- Audit requirements demand identical results across tools
+
+### Interpreting Differences Between Scanners
+
+When the same vulnerability appears with different severities or findings:
+
+#### Scenario 1: Same CVE, Different Severity
+
+```
+CVE-2024-12345:
+├─ Grype:  Medium (from Ubuntu advisory)
+└─ Trivy:  High (from NVD)
+```
+
+**Why this happens:**
+
+- **Grype**: Uses Ubuntu's severity assessment based on their specific build configuration, patches, and default settings
+- **Trivy**: Reports NVD's generic worst-case severity assessment
+
+**How to interpret:**
+
+- **If using Ubuntu packages**: Trust Grype's assessment (vendor knows their distribution)
+- **If compliance requires NVD**: Trust Trivy's assessment
+- **If unsure**: Investigate the CVE details and your specific configuration
+
+#### Scenario 2: Found by Grype Only
+
+```
+GHSA-xxxx-yyyy-zzzz (maps to CVE-2024-99999):
+├─ Found by Grype: ✓ (via GitHub Security Advisory)
+└─ Found by Trivy: ✗
+```
+
+**Why this happens:**
+
+- Grype's ecosystem-aware matching caught a language-specific vulnerability
+- May be newer advisory not yet in Trivy's database snapshot
+- Could be ecosystem-specific issue not relevant to CPE matching
+
+**How to interpret:**
+
+- **High priority** if it's a direct dependency in your language ecosystem
+- Verify the GHSA details and affected package versions
+- Check if your package manager confirms the vulnerability
+
+#### Scenario 3: Found by Trivy Only
+
+```
+CVE-2024-88888:
+├─ Found by Grype: ✗
+└─ Found by Trivy: ✓ (via CPE match)
+```
+
+**Why this happens:**
+
+- Trivy's broader CPE matching found the vulnerability
+- May be a valid finding that Grype's ecosystem matching missed
+- Could be a false positive from overly broad CPE matching
+
+**How to interpret:**
+
+- **Investigate carefully**: Check if the package name matches exactly
+- Look for version mismatches (different versioning schemes)
+- Verify if the vulnerability actually applies to your specific package variant
+- Consider if compile-time options or patches affect applicability
+
+#### Scenario 4: Found by Both, High Confidence
+
+```
+CVE-2024-77777:
+├─ Found by Grype: ✓ (Critical)
+└─ Found by Trivy: ✓ (Critical)
+```
+
+**How to interpret:**
+
+- **Highest priority**: Multiple independent sources confirm the vulnerability
+- Prioritize remediation immediately
+- Both ecosystem-aware and CPE matching agree on the finding
+
+### Strategic Multi-Scanner Workflow
+
+Use both scanners to maximize coverage while minimizing false positives:
+
+```bash
+# Step 1: Scan with Grype (ecosystem-aware, fewer false positives)
+grype registry.io/your-app:tag -o json > reports/grype-app.json
+
+# Step 2: Scan with Trivy (comprehensive coverage)
+# Option A: Use default auto priority (vendor > NVD)
+trivy image registry.io/your-app:tag -f json -o reports/trivy-app.json
+
+# Option B: Explicitly prioritize compliance-focused sources
+trivy image registry.io/your-app:tag \
+  --vuln-severity-source nvd,ghsa,redhat,debian \
+  -f json -o reports/trivy-app-compliance.json
+
+# Step 3: Aggregate results
+cve-report-aggregator -i reports/ -o unified-report.json -v
+
+# Step 4: Analyze with jq
+# High-confidence vulnerabilities (found by both)
+jq '.vulnerabilities[] | select(.count >= 2)' unified-report.json
+
+# Critical findings from either scanner
+jq '.vulnerabilities[] | select(.vulnerability.severity == "Critical")' unified-report.json
+
+# Summary comparison
+jq '.summary' unified-report.json
+```
+
+### Prioritization Framework
+
+Use this decision tree to prioritize remediation:
+
+```
+1. Found by BOTH scanners + Critical/High severity
+   → IMMEDIATE ACTION REQUIRED
+
+2. Found by Grype only + matches your ecosystem
+   → HIGH PRIORITY (ecosystem-specific issue)
+
+3. Found by both but different severities
+   → Review vendor advisory vs NVD, prioritize by your context
+
+4. Found by Trivy only + Critical
+   → INVESTIGATE (may be false positive, verify carefully)
+
+5. Found by Trivy only + Medium/Low
+   → MONITOR (likely false positive or edge case)
+```
+
+### Practical Tips
+
+1. **For Compliance Scanning**: Use Trivy with NVD priority
+
+   ```bash
+   trivy image --vuln-severity-source nvd <image>
+   ```
+
+1. **For Ecosystem-Specific Issues**: Use Grype's default behavior
+
+   ```bash
+   grype <image> -o json
+   ```
+
+1. **For False Positive Reduction**: Compare both and focus on overlapping findings
+
+   ```bash
+   # Count vulnerabilities found by both scanners
+   jq '.vulnerabilities[] | select(.count >= 2) | .vulnerability_id' unified-report.json
+   ```
+
+1. **For Language-Specific Projects**: Trust Grype's GHSA-based findings
+
+   ```bash
+   jq '.vulnerabilities[] |
+       select(.vulnerability_id | startswith("GHSA-"))' unified-report.json
+   ```
+
+1. **For Infrastructure/OS Images**: Consider both, with slight preference to Trivy's broader coverage
+
+   ```bash
+   # Compare distro-specific findings
+   jq '.vulnerabilities[] |
+       select(.affected_sources[].artifact.type == "deb" or
+              .affected_sources[].artifact.type == "rpm")' unified-report.json
+   ```
+
+### Real-World Example
+
+**Scenario**: Scanning a Python web application container based on Ubuntu
+
+```bash
+# Scan with both tools
+grype myapp:latest -o json > grype.json
+trivy image myapp:latest -f json > trivy.json
+
+# Aggregate
+cve-report-aggregator -i . -o unified.json -v
+```
+
+**Expected results**:
+
+- **Python package vulnerabilities**: Grype may find more via GHSA
+- **Ubuntu base image vulnerabilities**: Both should find similar issues
+- **System libraries (OpenSSL, etc.)**: Trivy may report higher severities (NVD-based)
+
+**Remediation strategy**:
+
+1. Fix all vulnerabilities found by **both** scanners (high confidence)
+1. Prioritize Grype's Python-specific findings (GHSA-based)
+1. Investigate Trivy-only findings for false positives
+1. Use vendor severity for Ubuntu packages, NVD for compliance reporting
+
+### When to Use Each Scanner Alone
+
+**Use Grype when:**
+
+- Scanning language-specific applications (Python, Node.js, Go, etc.)
+- You want fewer false positives
+- You trust vendor-specific severity assessments
+- Ecosystem context is critical
+
+**Use Trivy when:**
+
+- Compliance and audit requirements mandate NVD severity
+- You need comprehensive coverage across multiple data sources
+- Scanning Kubernetes resources or infrastructure-as-code
+- You want explicit control over severity source priority
+
+**Use both when:**
+
+- Security is critical (financial, healthcare, etc.)
+- You want maximum coverage with smart prioritization
+- You can dedicate time to investigating differences
+- You're building a comprehensive vulnerability management program
+
+### Additional Resources
+
+- **Comparative analysis**: [Grype vs Trivy Research Paper](https://www.montana.edu/cyber/products/Grype_Vs_Trivy_Boles_et_al.pdf)
+- **Grype ecosystem matching**: [Chainguard Guide](https://edu.chainguard.dev/chainguard/chainguard-images/staying-secure/working-with-scanners/grype-tutorial/)
+- **Trivy severity sources**: [Trivy Vulnerability Documentation](https://trivy.dev/dev/docs/scanner/vulnerability/)
 
 ## Example Workflow
 
@@ -528,11 +1106,3 @@ The script handles common errors gracefully:
 - **SBOM detection**: Automatically detects Syft SBOM files and scans them with Grype
 - **Tool validation**: Pydantic validates that required scanner tools (grype/trivy/syft) are installed
 - **Scanner errors**: Reports scanning failures with clear error messages
-
-## Related Scripts
-
-- `lint.py`: Quality gate script for Python projects (formatting, linting, testing)
-- Original project-specific scripts:
-  - `gitlab/aggregate_reports.py`: GitLab-specific aggregation
-  - `gitlab-runner/aggregate_reports.py`: GitLab Runner-specific aggregation
-  - `aggregate_unified_reports.py`: Combines multiple unified reports

--- a/cve-report-aggregator.py
+++ b/cve-report-aggregator.py
@@ -75,6 +75,10 @@ class AggregatorConfig(BaseModel):
         default=False,
         description="Enable verbose output with detailed processing information",
     )
+    use_highest_severity: bool = Field(
+        default=False,
+        description="Use highest severity across all scanner reports for each vulnerability",
+    )
 
     @field_validator("input_dir")
     @classmethod
@@ -480,7 +484,195 @@ def load_reports(
     return reports
 
 
-def deduplicate_vulnerabilities(reports: list[dict[str, Any]]) -> dict[str, Any]:
+def get_severity_rank(severity: str) -> int:
+    """Get numeric rank for severity level (higher = more severe).
+
+    Args:
+        severity: Severity string (e.g., "Critical", "High", "Medium").
+
+    Returns:
+        Integer rank where higher numbers indicate more severe vulnerabilities.
+    """
+    severity_map = {
+        "Critical": 5,
+        "High": 4,
+        "Medium": 3,
+        "Low": 2,
+        "Negligible": 1,
+        "Unknown": 0,
+    }
+    # Normalize to title case for comparison
+    normalized = severity.title() if severity else "Unknown"
+    return severity_map.get(normalized, 0)
+
+
+def extract_cvss3_scores(vuln_data: dict[str, Any]) -> list[float]:
+    """Extract all valid CVSS 3.x base scores from vulnerability data.
+
+    Handles both Grype and Trivy CVSS data formats:
+    - Grype: cvss is array of objects with version and metrics.baseScore
+    - Trivy: cvss is dict with vendor keys, each having V3Score
+
+    Args:
+        vuln_data: Vulnerability data dictionary.
+
+    Returns:
+        List of valid CVSS 3.x base scores (non-null, non-zero).
+    """
+    scores = []
+    cvss_data = vuln_data.get("cvss")
+
+    if not cvss_data:
+        return scores
+
+    # Handle Grype format: cvss is array
+    if isinstance(cvss_data, list):
+        for entry in cvss_data:
+            if not isinstance(entry, dict):
+                continue
+
+            version = entry.get("version", "")
+            # Check if it's CVSS version 3.x
+            if not version.startswith("3"):
+                continue
+
+            # Extract base score from metrics
+            metrics = entry.get("metrics", {})
+            if isinstance(metrics, dict):
+                base_score = metrics.get("baseScore")
+                if base_score is not None and base_score > 0:
+                    scores.append(float(base_score))
+
+    # Handle Trivy format: cvss is dict with vendor keys
+    elif isinstance(cvss_data, dict):
+        for vendor, vendor_data in cvss_data.items():
+            if not isinstance(vendor_data, dict):
+                continue
+
+            # Look for V3Score (CVSS version 3.x)
+            v3_score = vendor_data.get("V3Score")
+            if v3_score is not None and v3_score > 0:
+                scores.append(float(v3_score))
+
+    return scores
+
+
+def get_highest_cvss3_score(vuln_data: dict[str, Any]) -> float | None:
+    """Get the highest CVSS 3.x base score from vulnerability data.
+
+    Args:
+        vuln_data: Vulnerability data dictionary.
+
+    Returns:
+        Highest CVSS 3.x score, or None if no valid scores found.
+    """
+    scores = extract_cvss3_scores(vuln_data)
+    return max(scores) if scores else None
+
+
+def filter_null_cvss_scores(vuln_data: dict[str, Any]) -> dict[str, Any]:
+    """Remove CVSS entries with null/zero base scores from vulnerability data.
+
+    This function filters out invalid CVSS scores (null, N/A, or zero) from the
+    vulnerability data, ensuring only valid CVSS scores are included in reports.
+
+    Args:
+        vuln_data: Vulnerability data dictionary.
+
+    Returns:
+        Vulnerability data with filtered CVSS array (only valid scores remain).
+    """
+    if "cvss" not in vuln_data or not vuln_data["cvss"]:
+        return vuln_data
+
+    # Handle Grype format: cvss is array
+    if isinstance(vuln_data["cvss"], list):
+        filtered_cvss = []
+        for entry in vuln_data["cvss"]:
+            if not isinstance(entry, dict):
+                continue
+
+            # Check if base score exists and is valid
+            metrics = entry.get("metrics", {})
+            if isinstance(metrics, dict):
+                base_score = metrics.get("baseScore")
+                # Only include entries with non-null, non-zero scores
+                if base_score is not None and base_score > 0:
+                    filtered_cvss.append(entry)
+
+        # Update the cvss array with filtered results
+        vuln_data = vuln_data.copy()
+        vuln_data["cvss"] = filtered_cvss
+
+    # Handle Trivy format: cvss is dict with vendor keys
+    elif isinstance(vuln_data["cvss"], dict):
+        filtered_cvss = {}
+        for vendor, vendor_data in vuln_data["cvss"].items():
+            if not isinstance(vendor_data, dict):
+                continue
+
+            # Check for valid V3Score or V2Score
+            v3_score = vendor_data.get("V3Score")
+            v2_score = vendor_data.get("V2Score")
+
+            # Only include entries with at least one valid score
+            if (v3_score is not None and v3_score > 0) or (
+                v2_score is not None and v2_score > 0
+            ):
+                filtered_cvss[vendor] = vendor_data
+
+        # Update the cvss dict with filtered results
+        vuln_data = vuln_data.copy()
+        vuln_data["cvss"] = filtered_cvss
+
+    return vuln_data
+
+
+def select_highest_severity(current_data: dict[str, Any], new_data: dict[str, Any]) -> dict[str, Any]:
+    """Select vulnerability data with highest severity based on CVSS 3.x scores.
+
+    Prioritizes CVSS 3.x base score comparison over severity string comparison.
+    Falls back to severity string comparison if no CVSS 3.x scores are available.
+
+    Args:
+        current_data: Currently stored vulnerability data.
+        new_data: New vulnerability data to compare.
+
+    Returns:
+        Vulnerability data with the higher CVSS 3.x score or severity rating.
+    """
+    if current_data is None:
+        return new_data
+
+    # Try to compare using CVSS 3.x scores first
+    current_score = get_highest_cvss3_score(current_data)
+    new_score = get_highest_cvss3_score(new_data)
+
+    # If both have CVSS 3.x scores, compare numerically
+    if current_score is not None and new_score is not None:
+        return new_data if new_score > current_score else current_data
+
+    # If only new data has CVSS 3.x score, prefer it
+    if current_score is None and new_score is not None:
+        return new_data
+
+    # If only current data has CVSS 3.x score, keep it
+    if current_score is not None and new_score is None:
+        return current_data
+
+    # Fall back to severity string comparison if no CVSS 3.x scores
+    current_severity = current_data.get("severity", "Unknown")
+    new_severity = new_data.get("severity", "Unknown")
+
+    current_rank = get_severity_rank(current_severity)
+    new_rank = get_severity_rank(new_severity)
+
+    return new_data if new_rank > current_rank else current_data
+
+
+def deduplicate_vulnerabilities(
+    reports: list[dict[str, Any]], use_highest_severity: bool = False
+) -> dict[str, Any]:
     """Deduplicates vulnerabilities across all reports.
 
     Groups vulnerabilities by CVE ID (or GHSA if no CVE) and tracks
@@ -488,6 +680,8 @@ def deduplicate_vulnerabilities(reports: list[dict[str, Any]]) -> dict[str, Any]
 
     Args:
         reports: List of report dictionaries (Grype or Trivy format).
+        use_highest_severity: If True, selects vulnerability data with highest
+            severity across all scanner reports. If False, uses first occurrence.
 
     Returns:
         A dictionary mapping vulnerability IDs to aggregated data including:
@@ -542,21 +736,31 @@ def deduplicate_vulnerabilities(reports: list[dict[str, Any]]) -> dict[str, Any]
                     vuln_entry["affected_sources"].append(source_info)
 
                     # Store vulnerability data (convert to Grype-like format)
-                    if vuln_entry["vulnerability_data"] is None:
-                        vuln_entry["vulnerability_data"] = {
-                            "id": vuln_id,
-                            "severity": vuln.get("Severity", "Unknown"),
-                            "description": vuln.get("Description", ""),
-                            "cvss": vuln.get("CVSS", {}),
-                            "references": vuln.get("References", []),
-                            "publishedDate": vuln.get("PublishedDate", ""),
-                            "lastModifiedDate": vuln.get("LastModifiedDate", ""),
+                    new_vuln_data = {
+                        "id": vuln_id,
+                        "severity": vuln.get("Severity", "Unknown"),
+                        "description": vuln.get("Description", ""),
+                        "cvss": vuln.get("CVSS", {}),
+                        "references": vuln.get("References", []),
+                        "publishedDate": vuln.get("PublishedDate", ""),
+                        "lastModifiedDate": vuln.get("LastModifiedDate", ""),
+                    }
+                    if vuln.get("FixedVersion"):
+                        new_vuln_data["fix"] = {
+                            "versions": [vuln["FixedVersion"]],
+                            "state": "fixed",
                         }
-                        if vuln.get("FixedVersion"):
-                            vuln_entry["vulnerability_data"]["fix"] = {
-                                "versions": [vuln["FixedVersion"]],
-                                "state": "fixed",
-                            }
+
+                    # Filter out null/invalid CVSS scores
+                    new_vuln_data = filter_null_cvss_scores(new_vuln_data)
+
+                    # Select vulnerability data based on severity preference
+                    if use_highest_severity:
+                        vuln_entry["vulnerability_data"] = select_highest_severity(
+                            vuln_entry["vulnerability_data"], new_vuln_data
+                        )
+                    elif vuln_entry["vulnerability_data"] is None:
+                        vuln_entry["vulnerability_data"] = new_vuln_data
 
         else:
             # Process Grype format
@@ -598,9 +802,21 @@ def deduplicate_vulnerabilities(reports: list[dict[str, Any]]) -> dict[str, Any]
                 }
                 vuln_entry["affected_sources"].append(source_info)
 
-                # Store vulnerability data (from first occurrence)
-                if vuln_entry["vulnerability_data"] is None:
-                    vuln_entry["vulnerability_data"] = match["vulnerability"]
+                # Filter out null/invalid CVSS scores
+                filtered_vuln_data = filter_null_cvss_scores(match["vulnerability"])
+
+                # Store vulnerability data based on severity preference
+                if use_highest_severity:
+                    vuln_entry["vulnerability_data"] = select_highest_severity(
+                        vuln_entry["vulnerability_data"], filtered_vuln_data
+                    )
+                    # Update related vulnerabilities if we selected new data
+                    if vuln_entry["vulnerability_data"] == filtered_vuln_data:
+                        vuln_entry["related_vulnerabilities"] = match.get(
+                            "relatedVulnerabilities", []
+                        )
+                elif vuln_entry["vulnerability_data"] is None:
+                    vuln_entry["vulnerability_data"] = filtered_vuln_data
                     vuln_entry["related_vulnerabilities"] = match.get(
                         "relatedVulnerabilities", []
                     )
@@ -796,6 +1012,15 @@ Examples:
         help="Enable verbose output with detailed processing information",
     )
 
+    parser.add_argument(
+        "--use-highest-severity",
+        action="store_true",
+        help=(
+            "Use highest severity rating across all scanner reports for each vulnerability. "
+            "By default, uses the severity from the first report processed (alphabetical order)."
+        ),
+    )
+
     args = parser.parse_args()
 
     # Validate arguments using Pydantic
@@ -805,6 +1030,7 @@ Examples:
             output_file=args.output_file,
             scanner=args.scanner,
             verbose=args.verbose,
+            use_highest_severity=args.use_highest_severity,
         )
         return config
     except ValueError as e:
@@ -871,7 +1097,7 @@ def main() -> None:
         console=console,
     ) as progress:
         task = progress.add_task("[cyan]Deduplicating vulnerabilities...", total=None)
-        vuln_map = deduplicate_vulnerabilities(reports)
+        vuln_map = deduplicate_vulnerabilities(reports, config.use_highest_severity)
         progress.update(task, completed=True)
 
     # Create unified report


### PR DESCRIPTION
- Introduced option to select highest severity across scanner reports.
- Added functions to extract and filter CVSS scores.
- Updated deduplication logic to incorporate highest severity selection.
- Enhanced command-line interface with `--use-highest-severity` flag.