### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,5 +1,7 @@
 ---
 name: Semgrep Code Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mkm29/cve-report-aggregator/security/code-scanning/16](https://github.com/mkm29/cve-report-aggregator/security/code-scanning/16)

The best fix is to explicitly define a permissions block at the workflow level (applies to all jobs), immediately beneath the workflow’s `name` entry—or at the relevant job (here: `semgrep`) if the intent is only to restrict that job. Since this workflow has just one job, either is valid, but adding it at the top (root of the workflow) is clearer and conventional. The absolute minimum permissions required are read-only access to repository contents, i.e., `permissions: {contents: read}`. 

**How to implement:**  
- Insert the following lines immediately beneath the workflow `name` (after line 2 in your snippet):

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN only has read access to code in all jobs (here, just `semgrep`), adhering to least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
