### PR TITLE
refactor: extract app/ composition layer; decouple core/ from enhance/

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,3 +208,44 @@ The complete processing pipeline consists of seven stages:
    - Per-package JSON reports: `<package>-<version>.json`
    - Per-package CSV reports: `<package>-<version>.csv`
    - Executive summary: `executive-summary-<timestamp>.json`
+
+## Layering Rules
+
+The codebase enforces a three-layer architecture for the aggregation workflow:
+
+```mermaid
+flowchart TB
+    cli[cli.py]
+    app["app/<br/>(composition layer)"]
+    core["core/<br/>(data operations)"]
+    enhance["enhance/<br/>(LLM enrichment providers)"]
+    io["io/, processing/<br/>(I/O & data utilities)"]
+
+    cli --> app
+    app --> core
+    app --> enhance
+    enhance --> core
+    core --> io
+    enhance --> io
+
+    classDef layer fill:#1976d2,stroke:#0d47a1,color:#fff
+    classDef forbidden stroke:#d32f2f,stroke-dasharray:5 5
+    class cli,app,core,enhance,io layer
+```
+
+The boundaries:
+
+- **`core/`** owns SBOM acquisition, report loading, deduplication, statistics aggregation, executive summary creation,
+  and the `AggregationResult` data type. It must not import from `enhance/` or `app/`.
+- **`enhance/`** owns the AI enrichment provider hierarchy (Anthropic, OpenAI, OpenRouter, Mock, Pipeline). It depends
+  on `core/` for shared models and logging. It must not import from `app/`.
+- **`app/pipeline.py`** is the only place the two layers are wired together — it owns `run_aggregation`,
+  `process_package_reports`, and `enrich_report`. It imports freely from both `core/` and `enhance/`.
+
+The invariant is enforced by `tests/unit/test_layering.py`, which uses AST analysis to fail CI if any module under
+`core/` imports from `enhance/`, or any module under `enhance/` imports from `app/`.
+
+**Why this matters:** the aggregation pipeline is genuinely a composition of two independent capabilities (vulnerability
+data processing and LLM enrichment). Forcing the composition into a dedicated layer keeps each subsystem replaceable — a
+future caller could use `core/` standalone for unenriched aggregation, or replace `enhance/` with a different enrichment
+backend, without touching the other.

--- a/src/cve_report_aggregator/app/__init__.py
+++ b/src/cve_report_aggregator/app/__init__.py
@@ -1,0 +1,10 @@
+"""Application composition layer.
+
+This package wires `core/` building blocks together with `enhance/` providers.
+It is the only layer allowed to import from both — `core/` and `enhance/`
+must not depend on each other or on this package.
+"""
+
+from .pipeline import AggregationResult, run_aggregation
+
+__all__ = ["AggregationResult", "run_aggregation"]

--- a/src/cve_report_aggregator/app/pipeline.py
+++ b/src/cve_report_aggregator/app/pipeline.py
@@ -1,0 +1,355 @@
+"""Application pipeline composing core data operations with enhance providers.
+
+This module owns the top-level aggregation workflow (`run_aggregation`) and
+the per-package processing that combines deduplication, unified report
+creation, optional CVE enrichment, and report persistence.
+
+Importantly: this is the *only* place where `core/` and `enhance/` are wired
+together. Neither of those packages may import from the other; composition
+happens here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ..core.orchestrator import (
+    AggregationResult,
+    _collect_artifacts_for_tarball,
+    _create_tarball_archive,
+    _determine_output_path,
+    _export_csv_report,
+    _find_package_version,
+    _merge_vulnerability_entry,
+    _write_json_report,
+    acquire_sboms,
+    aggregate_statistics,
+    create_executive_summary_report,
+    load_and_group_reports,
+)
+from ..enhance import create_enricher
+from ..io.report import create_unified_report
+from ..processing.aggregator import deduplicate_vulnerabilities
+
+if TYPE_CHECKING:
+    from structlog.types import FilteringBoundLogger
+
+    from ..context import AppContext
+
+
+def _count_eligible_cves(vulnerabilities: list[dict[str, Any]], severity_filter: list[str]) -> int:
+    """Count CVEs matching the severity filter.
+
+    Args:
+        vulnerabilities: List of vulnerability dictionaries
+        severity_filter: List of severity levels to match
+
+    Returns:
+        Number of CVEs matching the severity filter
+    """
+    return sum(1 for vuln in vulnerabilities if vuln.get("vulnerability", {}).get("severity") in severity_filter)
+
+
+def _build_enrichment_summary(
+    vulnerabilities: list[dict[str, Any]],
+    enriched_count: int,
+    config: Any,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Build enrichment summary statistics.
+
+    Args:
+        vulnerabilities: List of vulnerability dictionaries
+        enriched_count: Number of successfully enriched CVEs
+        config: Enrichment configuration
+        error: Error message if enrichment failed
+
+    Returns:
+        Enrichment summary dictionary
+    """
+    eligible_cves = _count_eligible_cves(vulnerabilities, config.severities)
+    summary: dict[str, Any] = {
+        "enabled": True,
+        "total_cves": len(vulnerabilities),
+        "eligible_cves": eligible_cves,
+        "enriched_cves": enriched_count,
+        "severity_filter": config.severities,
+    }
+    if enriched_count > 0:
+        summary["model"] = config.model
+    if error:
+        summary["error"] = error
+    return summary
+
+
+def enrich_report(
+    unified_report: dict[str, Any],
+    package_name: str,
+    context: AppContext,
+) -> dict[str, Any]:
+    """Enrich unified report with OpenRouter CVE analysis.
+
+    Args:
+        unified_report: Unified report dictionary
+        package_name: Name of the package being enriched
+        context: Application context with configuration
+
+    Returns:
+        Updated unified report with enrichment data
+
+    Note:
+        Configuration errors are re-raised (invalid API key, unknown provider).
+        API/network errors are logged but allow processing to continue.
+    """
+    from ..enhance.exceptions import ConfigurationError, EnrichmentError
+
+    config = context.config
+    logger = context.get_logger(__name__)
+
+    if not config.enrich.api_key:
+        logger.warning(
+            "CVE enrichment enabled but no API key provided",
+            package=package_name,
+        )
+        return unified_report
+
+    vulnerabilities = unified_report.get("vulnerabilities", [])
+
+    try:
+        enricher = create_enricher(config.enrich)
+
+        enrichments = enricher.enrich_report(
+            vulnerabilities=vulnerabilities,
+            max_cves=None,
+            severity_filter=config.enrich.severities,
+        )
+
+        unified_report["enrichments"] = {cve_id: enrichment.model_dump() for cve_id, enrichment in enrichments.items()}
+
+        if "summary" not in unified_report:
+            unified_report["summary"] = {}
+        unified_report["summary"]["enrichment"] = _build_enrichment_summary(
+            vulnerabilities, len(enrichments), config.enrich
+        )
+
+        logger.info(
+            "Enriched CVEs",
+            package=package_name,
+            enriched=len(enrichments),
+            total=len(vulnerabilities),
+        )
+
+    except ConfigurationError:
+        raise
+
+    except EnrichmentError as e:
+        logger.warning(
+            "CVE enrichment failed, continuing without enrichment",
+            package=package_name,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        unified_report["enrichments"] = {}
+        if "summary" not in unified_report:
+            unified_report["summary"] = {}
+        unified_report["summary"]["enrichment"] = _build_enrichment_summary(
+            vulnerabilities, 0, config.enrich, error=str(e)
+        )
+
+    except Exception as e:
+        logger.error(
+            "Unexpected error during CVE enrichment",
+            package=package_name,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        unified_report["enrichments"] = {}
+        if "summary" not in unified_report:
+            unified_report["summary"] = {}
+        unified_report["summary"]["enrichment"] = _build_enrichment_summary(
+            vulnerabilities, 0, config.enrich, error=str(e)
+        )
+
+    return unified_report
+
+
+def process_package_reports(
+    package_name: str,
+    package_reports: list[dict[str, Any]],
+    context: AppContext,
+) -> tuple[Path, Path | None, dict[str, Any]]:
+    """Process reports for a single package.
+
+    This function coordinates:
+    1. Vulnerability deduplication
+    2. Unified report creation
+    3. CVE enrichment (if enabled)
+    4. Report persistence (JSON and CSV)
+
+    Args:
+        package_name: Name of the package
+        package_reports: List of reports for this package
+        context: Application context with configuration
+
+    Returns:
+        Tuple of (JSON output path, CSV output path, vulnerability map)
+    """
+    config = context.config
+    logger = context.get_logger(__name__)
+
+    package_version = _find_package_version(package_name, config)
+
+    vuln_map = deduplicate_vulnerabilities(package_reports, config.mode)
+
+    logger.info(
+        "Deduplicated vulnerabilities",
+        package=package_name,
+        unique_count=len(vuln_map),
+    )
+
+    unified_report = create_unified_report(
+        vuln_map,
+        package_reports,
+        package_name=package_name,
+        package_version=package_version,
+    )
+
+    if config.enrich.enabled:
+        unified_report = enrich_report(
+            unified_report=unified_report,
+            package_name=package_name,
+            context=context,
+        )
+
+    output_dir = config.output_file.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = _determine_output_path(package_name, package_version, output_dir)
+    _write_json_report(unified_report, json_path, package_name, logger)
+    csv_path = _export_csv_report(unified_report, json_path, package_name, logger)
+
+    return (json_path, csv_path, vuln_map)
+
+
+def _process_all_packages(
+    reports_by_package: dict[str, list[dict[str, Any]]],
+    context: AppContext,
+    logger: FilteringBoundLogger,
+) -> tuple[list[Path], list[dict[str, Any]], dict[str, Any]]:
+    """Process all packages and collect results.
+
+    Args:
+        reports_by_package: Reports grouped by package name
+        context: Application context
+        logger: Logger instance
+
+    Returns:
+        Tuple of (output_files, all_reports, merged_vuln_maps)
+    """
+    output_files: list[Path] = []
+    all_reports: list[dict[str, Any]] = []
+    all_vuln_maps: dict[str, Any] = {}
+
+    for package_name, package_reports in reports_by_package.items():
+        logger.info(
+            "Processing package",
+            package=package_name,
+            report_count=len(package_reports),
+        )
+
+        json_path, csv_path, vuln_map = process_package_reports(
+            package_name=package_name,
+            package_reports=package_reports,
+            context=context,
+        )
+
+        output_files.append(json_path)
+        if csv_path:
+            output_files.append(csv_path)
+
+        all_reports.extend(package_reports)
+
+        for vuln_id, vuln_entry in vuln_map.items():
+            _merge_vulnerability_entry(all_vuln_maps, vuln_id, vuln_entry)
+
+    return output_files, all_reports, all_vuln_maps
+
+
+def run_aggregation(context: AppContext) -> AggregationResult:
+    """Main orchestration function that coordinates the entire workflow.
+
+    This is the primary entry point for the aggregation process. It:
+    1. Acquires SBOMs (local or remote)
+    2. Loads and groups reports by package
+    3. Processes each package (deduplicate, enrich, export)
+    4. Creates executive summary
+    5. Aggregates statistics
+    6. Creates tarball archive (if configured)
+
+    Args:
+        context: Application context with configuration and services
+
+    Returns:
+        AggregationResult with output files and statistics
+
+    Raises:
+        ValueError: If configuration is invalid or no reports found
+        RuntimeError: If critical processing steps fail
+    """
+    logger = context.get_logger(__name__)
+    config = context.config
+
+    logger.info("Starting aggregation workflow")
+
+    # Step 1: Acquire SBOMs (local or remote)
+    sboms, local_sboms_found = acquire_sboms(context)
+    if sboms:
+        logger.info(
+            "Acquired SBOMs",
+            count=len(sboms),
+            source="local" if local_sboms_found else "remote",
+        )
+
+    # Step 2: Load and group reports by package
+    reports_by_package = load_and_group_reports(context)
+    logger.info("Grouped reports by package", packages=list(reports_by_package.keys()))
+
+    # Step 3: Process each package's reports
+    output_files, all_reports, all_vuln_maps = _process_all_packages(reports_by_package, context, logger)
+
+    # Step 4: Create executive summary for all packages
+    if all_vuln_maps and all_reports:
+        executive_summary_file = create_executive_summary_report(
+            all_vuln_maps=all_vuln_maps,
+            all_reports=all_reports,
+            context=context,
+        )
+        output_files.append(executive_summary_file)
+
+    # Step 5: Aggregate statistics
+    result = aggregate_statistics(output_files, context)
+
+    # Step 6: Create tarball archive (default: ~/output, or configured archive_dir)
+    archive_dir = config.archive_dir or (Path.home() / "output")
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    artifact_files = _collect_artifacts_for_tarball(output_files, config.input_dir, logger)
+    if artifact_files:
+        _create_tarball_archive(archive_dir, artifact_files, result, context, logger)
+
+    logger.info(
+        "Aggregation workflow completed",
+        packages_scanned=result.packages_scanned,
+        unique_vulnerabilities=result.unique_vulnerabilities,
+        output_files=len(output_files),
+    )
+
+    return result
+
+
+__all__ = [
+    "AggregationResult",
+    "enrich_report",
+    "process_package_reports",
+    "run_aggregation",
+]

--- a/src/cve_report_aggregator/cli.py
+++ b/src/cve_report_aggregator/cli.py
@@ -15,10 +15,10 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from . import __version__
+from .app import AggregationResult, run_aggregation
 from .context import AppContext
 from .core.config import AggregatorConfig, get_config, set_config
 from .core.models import ScannerType
-from .core.orchestrator import AggregationResult, run_aggregation
 from .core.validation import MissingToolError, validate_configuration, validate_scanner_tools
 from .utils import ASCII_LOGO, check_command_exists, get_scanner_version
 

--- a/src/cve_report_aggregator/core/__init__.py
+++ b/src/cve_report_aggregator/core/__init__.py
@@ -21,7 +21,7 @@ from .exceptions import AuthenticationError, ConfigurationError, DownloadError, 
 from .executor import ExecutorManager
 from .logging import get_logger
 from .models import AggregatorConfig, EnrichmentConfig, ModeType, PackageConfig, ScannerType
-from .orchestrator import AggregationResult, run_aggregation
+from .orchestrator import AggregationResult
 from .validation import (
     ConfigValidationError,
     MissingToolError,
@@ -53,8 +53,7 @@ __all__ = [
     "validate_trivy_requirements",
     "validate_uds_requirements",
     "validate_zarf_requirements",
-    # Orchestration
-    "run_aggregation",
+    # Orchestration data types
     "AggregationResult",
     # Error handling
     "ErrorHandler",

--- a/src/cve_report_aggregator/core/orchestrator.py
+++ b/src/cve_report_aggregator/core/orchestrator.py
@@ -1,8 +1,10 @@
-"""Orchestration logic for CVE Report Aggregator.
+"""Core orchestration building blocks for CVE Report Aggregator.
 
-This module contains the main workflow coordination for aggregating
-vulnerability reports. It handles SBOM acquisition, report loading,
-deduplication, enrichment, and report generation.
+This module contains data-acquisition, report-loading, and aggregation
+operations that have no knowledge of CVE enrichment. Composition with
+the enrichment subsystem (`enhance/`) lives in `app.pipeline` — this
+module must not import from `enhance/`, and `enhance/` must not import
+from `app/`.
 
 The orchestrator is designed to be testable independently from the CLI
 and can be used from other entry points (API, GUI, etc.).
@@ -15,12 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..core.models import PackageConfig, ScannerType
-from ..enhance import create_enricher
 from ..io.csv_export import export_to_csv
 from ..io.downloader import download_package_sboms
 from ..io.local_packages import scan_local_packages
-from ..io.report import create_executive_summary, create_unified_report
-from ..processing.aggregator import deduplicate_vulnerabilities
+from ..io.report import create_executive_summary
 from ..processing.scanner import load_reports
 from ..utils import check_command_exists
 
@@ -507,212 +507,6 @@ def _export_csv_report(
         return None
 
 
-def process_package_reports(
-    package_name: str,
-    package_reports: list[dict[str, Any]],
-    context: AppContext,
-) -> tuple[Path, Path | None, dict[str, Any]]:
-    """Process reports for a single package.
-
-    This function coordinates:
-    1. Vulnerability deduplication
-    2. Unified report creation
-    3. CVE enrichment (if enabled)
-    4. Report persistence (JSON and CSV)
-
-    Args:
-        package_name: Name of the package
-        package_reports: List of reports for this package
-        context: Application context with configuration
-
-    Returns:
-        Tuple of (JSON output path, CSV output path, vulnerability map)
-    """
-    config = context.config
-    logger = context.get_logger(__name__)
-
-    # Find package version from configuration
-    package_version = _find_package_version(package_name, config)
-
-    # Deduplicate vulnerabilities for this package
-    vuln_map = deduplicate_vulnerabilities(package_reports, config.mode)
-
-    logger.info(
-        "Deduplicated vulnerabilities",
-        package=package_name,
-        unique_count=len(vuln_map),
-    )
-
-    # Create unified report
-    unified_report = create_unified_report(
-        vuln_map,
-        package_reports,
-        package_name=package_name,
-        package_version=package_version,
-    )
-
-    # Enrich CVEs with OpenAI if enabled
-    if config.enrich.enabled:
-        unified_report = enrich_report(
-            unified_report=unified_report,
-            package_name=package_name,
-            context=context,
-        )
-
-    # Write reports to disk using configured output directory
-    output_dir = config.output_file.parent
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    json_path = _determine_output_path(package_name, package_version, output_dir)
-    _write_json_report(unified_report, json_path, package_name, logger)
-    csv_path = _export_csv_report(unified_report, json_path, package_name, logger)
-
-    return (json_path, csv_path, vuln_map)
-
-
-def _count_eligible_cves(vulnerabilities: list[dict[str, Any]], severity_filter: list[str]) -> int:
-    """Count CVEs matching the severity filter.
-
-    Args:
-        vulnerabilities: List of vulnerability dictionaries
-        severity_filter: List of severity levels to match
-
-    Returns:
-        Number of CVEs matching the severity filter
-    """
-    return sum(1 for vuln in vulnerabilities if vuln.get("vulnerability", {}).get("severity") in severity_filter)
-
-
-def _build_enrichment_summary(
-    vulnerabilities: list[dict[str, Any]],
-    enriched_count: int,
-    config: Any,
-    error: str | None = None,
-) -> dict[str, Any]:
-    """Build enrichment summary statistics.
-
-    Args:
-        vulnerabilities: List of vulnerability dictionaries
-        enriched_count: Number of successfully enriched CVEs
-        config: Enrichment configuration
-        error: Error message if enrichment failed
-
-    Returns:
-        Enrichment summary dictionary
-    """
-    eligible_cves = _count_eligible_cves(vulnerabilities, config.severities)
-    summary: dict[str, Any] = {
-        "enabled": True,
-        "total_cves": len(vulnerabilities),
-        "eligible_cves": eligible_cves,
-        "enriched_cves": enriched_count,
-        "severity_filter": config.severities,
-    }
-    if enriched_count > 0:
-        summary["model"] = config.model
-    if error:
-        summary["error"] = error
-    return summary
-
-
-def enrich_report(
-    unified_report: dict[str, Any],
-    package_name: str,
-    context: AppContext,
-) -> dict[str, Any]:
-    """Enrich unified report with OpenRouter CVE analysis.
-
-    Args:
-        unified_report: Unified report dictionary
-        package_name: Name of the package being enriched
-        context: Application context with configuration
-
-    Returns:
-        Updated unified report with enrichment data
-
-    Note:
-        Configuration errors are re-raised (invalid API key, unknown provider).
-        API/network errors are logged but allow processing to continue.
-    """
-    from ..enhance.exceptions import ConfigurationError, EnrichmentError
-
-    config = context.config
-    logger = context.get_logger(__name__)
-
-    if not config.enrich.api_key:
-        logger.warning(
-            "CVE enrichment enabled but no API key provided",
-            package=package_name,
-        )
-        return unified_report
-
-    vulnerabilities = unified_report.get("vulnerabilities", [])
-
-    try:
-        # Use factory to create enricher based on configuration
-        enricher = create_enricher(config.enrich)
-
-        # Enrich vulnerabilities
-        enrichments = enricher.enrich_report(
-            vulnerabilities=vulnerabilities,
-            max_cves=None,
-            severity_filter=config.enrich.severities,
-        )
-
-        # Add enrichments to unified report
-        unified_report["enrichments"] = {cve_id: enrichment.model_dump() for cve_id, enrichment in enrichments.items()}
-
-        # Update summary with enrichment statistics
-        if "summary" not in unified_report:
-            unified_report["summary"] = {}
-        unified_report["summary"]["enrichment"] = _build_enrichment_summary(
-            vulnerabilities, len(enrichments), config.enrich
-        )
-
-        logger.info(
-            "Enriched CVEs",
-            package=package_name,
-            enriched=len(enrichments),
-            total=len(vulnerabilities),
-        )
-
-    except ConfigurationError:
-        # Configuration errors should propagate - they indicate a setup problem
-        raise
-
-    except EnrichmentError as e:
-        # Expected enrichment errors (API issues, timeouts) - continue without enrichment
-        logger.warning(
-            "CVE enrichment failed, continuing without enrichment",
-            package=package_name,
-            error=str(e),
-            error_type=type(e).__name__,
-        )
-        unified_report["enrichments"] = {}
-        if "summary" not in unified_report:
-            unified_report["summary"] = {}
-        unified_report["summary"]["enrichment"] = _build_enrichment_summary(
-            vulnerabilities, 0, config.enrich, error=str(e)
-        )
-
-    except Exception as e:
-        # Unexpected errors - log at error level but continue
-        logger.error(
-            "Unexpected error during CVE enrichment",
-            package=package_name,
-            error=str(e),
-            error_type=type(e).__name__,
-        )
-        unified_report["enrichments"] = {}
-        if "summary" not in unified_report:
-            unified_report["summary"] = {}
-        unified_report["summary"]["enrichment"] = _build_enrichment_summary(
-            vulnerabilities, 0, config.enrich, error=str(e)
-        )
-
-    return unified_report
-
-
 def create_executive_summary_report(
     all_vuln_maps: dict[str, Any],
     all_reports: list[dict[str, Any]],
@@ -931,130 +725,11 @@ def _create_tarball_archive(
         )
 
 
-def _process_all_packages(
-    reports_by_package: dict[str, list[dict[str, Any]]],
-    context: AppContext,
-    logger: FilteringBoundLogger,
-) -> tuple[list[Path], list[dict[str, Any]], dict[str, Any]]:
-    """Process all packages and collect results.
-
-    Args:
-        reports_by_package: Reports grouped by package name
-        context: Application context
-        logger: Logger instance
-
-    Returns:
-        Tuple of (output_files, all_reports, merged_vuln_maps)
-    """
-    output_files: list[Path] = []
-    all_reports: list[dict[str, Any]] = []
-    all_vuln_maps: dict[str, Any] = {}
-
-    for package_name, package_reports in reports_by_package.items():
-        logger.info(
-            "Processing package",
-            package=package_name,
-            report_count=len(package_reports),
-        )
-
-        json_path, csv_path, vuln_map = process_package_reports(
-            package_name=package_name,
-            package_reports=package_reports,
-            context=context,
-        )
-
-        output_files.append(json_path)
-        if csv_path:
-            output_files.append(csv_path)
-
-        all_reports.extend(package_reports)
-
-        # Merge vulnerability maps across packages
-        for vuln_id, vuln_entry in vuln_map.items():
-            _merge_vulnerability_entry(all_vuln_maps, vuln_id, vuln_entry)
-
-    return output_files, all_reports, all_vuln_maps
-
-
-def run_aggregation(context: AppContext) -> AggregationResult:
-    """Main orchestration function that coordinates the entire workflow.
-
-    This is the primary entry point for the aggregation process. It:
-    1. Acquires SBOMs (local or remote)
-    2. Loads and groups reports by package
-    3. Processes each package (deduplicate, enrich, export)
-    4. Creates executive summary
-    5. Aggregates statistics
-    6. Creates tarball archive (if configured)
-
-    Args:
-        context: Application context with configuration and services
-
-    Returns:
-        AggregationResult with output files and statistics
-
-    Raises:
-        ValueError: If configuration is invalid or no reports found
-        RuntimeError: If critical processing steps fail
-    """
-    logger = context.get_logger(__name__)
-    config = context.config
-
-    logger.info("Starting aggregation workflow")
-
-    # Step 1: Acquire SBOMs (local or remote)
-    sboms, local_sboms_found = acquire_sboms(context)
-    if sboms:
-        logger.info(
-            "Acquired SBOMs",
-            count=len(sboms),
-            source="local" if local_sboms_found else "remote",
-        )
-
-    # Step 2: Load and group reports by package
-    reports_by_package = load_and_group_reports(context)
-    logger.info("Grouped reports by package", packages=list(reports_by_package.keys()))
-
-    # Step 3: Process each package's reports
-    output_files, all_reports, all_vuln_maps = _process_all_packages(reports_by_package, context, logger)
-
-    # Step 4: Create executive summary for all packages
-    if all_vuln_maps and all_reports:
-        executive_summary_file = create_executive_summary_report(
-            all_vuln_maps=all_vuln_maps,
-            all_reports=all_reports,
-            context=context,
-        )
-        output_files.append(executive_summary_file)
-
-    # Step 5: Aggregate statistics
-    result = aggregate_statistics(output_files, context)
-
-    # Step 6: Create tarball archive (default: ~/output, or configured archive_dir)
-    archive_dir = config.archive_dir or (Path.home() / "output")
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    artifact_files = _collect_artifacts_for_tarball(output_files, config.input_dir, logger)
-    if artifact_files:
-        _create_tarball_archive(archive_dir, artifact_files, result, context, logger)
-
-    logger.info(
-        "Aggregation workflow completed",
-        packages_scanned=result.packages_scanned,
-        unique_vulnerabilities=result.unique_vulnerabilities,
-        output_files=len(output_files),
-    )
-
-    return result
-
-
 # Public API
 __all__ = [
     "AggregationResult",
     "acquire_sboms",
     "load_and_group_reports",
-    "process_package_reports",
-    "enrich_report",
     "create_executive_summary_report",
     "aggregate_statistics",
-    "run_aggregation",
 ]

--- a/tests/unit/app/test_pipeline.py
+++ b/tests/unit/app/test_pipeline.py
@@ -1,0 +1,43 @@
+"""Smoke tests for the app.pipeline composition layer.
+
+The bulk of pipeline behavior is exercised by tests/unit/test_orchestrator.py,
+which imports the moved functions from their new home in app.pipeline.
+This file pins down the package-level public API surface so a future
+reorganization can't silently break it.
+"""
+
+from cve_report_aggregator.app import AggregationResult, run_aggregation
+from cve_report_aggregator.app.pipeline import (
+    enrich_report,
+    process_package_reports,
+)
+
+
+def test_app_package_re_exports_aggregation_result_and_run_aggregation() -> None:
+    """`from cve_report_aggregator.app import AggregationResult, run_aggregation` must work.
+
+    cli.py depends on this exact import path. Anything that breaks it is a
+    user-visible regression even if the underlying functions still exist.
+    """
+    assert AggregationResult is not None
+    assert callable(run_aggregation)
+
+
+def test_aggregation_result_identity_is_shared_with_core() -> None:
+    """`AggregationResult` must be the same class regardless of import path.
+
+    `core.orchestrator` defines it (because it's a pure data type with no
+    enhance/ knowledge); `app` re-exports it. If they ever drift apart, code
+    that constructs the type from one path and checks isinstance from the
+    other will silently fail.
+    """
+    from cve_report_aggregator.core.orchestrator import AggregationResult as core_result
+
+    assert AggregationResult is core_result
+
+
+def test_pipeline_module_exposes_composition_functions() -> None:
+    """The functions composing core + enhance must live in app.pipeline."""
+    assert callable(enrich_report)
+    assert callable(process_package_reports)
+    assert callable(run_aggregation)

--- a/tests/unit/test_layering.py
+++ b/tests/unit/test_layering.py
@@ -1,0 +1,67 @@
+"""Architectural invariant tests.
+
+These tests pin layering decisions into CI so they cannot silently regress.
+"""
+
+import ast
+import pathlib
+
+
+def _collect_imports(directory: pathlib.Path) -> list[tuple[pathlib.Path, int, str]]:
+    """Yield (file, lineno, module) for every `from X import …` and `import X` in a tree."""
+    found: list[tuple[pathlib.Path, int, str]] = []
+    for py_file in directory.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                found.append((py_file, node.lineno, node.module))
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    found.append((py_file, node.lineno, alias.name))
+    return found
+
+
+def _package_root() -> pathlib.Path:
+    """Return src/cve_report_aggregator regardless of where tests are run from."""
+    here = pathlib.Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "src" / "cve_report_aggregator"
+        if candidate.exists():
+            return candidate
+    raise RuntimeError("Could not locate src/cve_report_aggregator")
+
+
+def test_core_does_not_import_enhance() -> None:
+    """core/ must not depend on enhance/.
+
+    The composition between core (data operations) and enhance (LLM enrichment
+    providers) belongs in the app/ layer. Allowing core to import from enhance
+    creates a dependency cycle in the architectural graph and makes the
+    enrichment subsystem impossible to remove or replace cleanly.
+    """
+    core = _package_root() / "core"
+    violations = [
+        f"{path.relative_to(_package_root().parent.parent)}:{lineno} imports {module}"
+        for path, lineno, module in _collect_imports(core)
+        if "enhance" in module.split(".")
+    ]
+    assert not violations, "core/ must not import from enhance/:\n  " + "\n  ".join(violations)
+
+
+def test_enhance_does_not_import_app() -> None:
+    """enhance/ must not depend on app/ either.
+
+    enhance/ depends on core/ (for shared models and logging) — that direction
+    is fine. But enhance/ must not reach up into app/, which would invert the
+    layering and recreate the same coupling problem.
+    """
+    enhance = _package_root() / "enhance"
+    violations = [
+        f"{path.relative_to(_package_root().parent.parent)}:{lineno} imports {module}"
+        for path, lineno, module in _collect_imports(enhance)
+        if module.startswith("cve_report_aggregator.app") or "..app" in module or ".app" == module
+    ]
+    assert not violations, "enhance/ must not import from app/:\n  " + "\n  ".join(violations)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6,6 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
+from cve_report_aggregator.app.pipeline import (
+    enrich_report,
+    process_package_reports,
+    run_aggregation,
+)
 from cve_report_aggregator.context import AppContext
 from cve_report_aggregator.core.exceptions import ReportLoadError
 from cve_report_aggregator.core.models import AggregatorConfig, PackageConfig
@@ -14,10 +19,7 @@ from cve_report_aggregator.core.orchestrator import (
     acquire_sboms,
     aggregate_statistics,
     create_executive_summary_report,
-    enrich_report,
     load_and_group_reports,
-    process_package_reports,
-    run_aggregation,
 )
 
 
@@ -400,7 +402,7 @@ class TestProcessPackageReports:
         report["_source_file"] = "test.json"
         reports = [report]
 
-        with patch("cve_report_aggregator.core.orchestrator.create_enricher") as mock_create_enricher:
+        with patch("cve_report_aggregator.app.pipeline.create_enricher") as mock_create_enricher:
             from cve_report_aggregator.enhance.models import CVEEnricher
 
             mock_enricher = mock_create_enricher.return_value
@@ -480,7 +482,7 @@ class TestEnrichReport:
             ],
         }
 
-        with patch("cve_report_aggregator.core.orchestrator.create_enricher") as mock_create_enricher:
+        with patch("cve_report_aggregator.app.pipeline.create_enricher") as mock_create_enricher:
             from cve_report_aggregator.enhance.models import CVEEnricher
 
             mock_enricher = mock_create_enricher.return_value
@@ -524,7 +526,7 @@ class TestEnrichReport:
             ],
         }
 
-        with patch("cve_report_aggregator.core.orchestrator.create_enricher") as mock_create_enricher:
+        with patch("cve_report_aggregator.app.pipeline.create_enricher") as mock_create_enricher:
             mock_create_enricher.side_effect = Exception("OpenAI API error")
 
             result = enrich_report(unified_report, "test-package", context)
@@ -1001,7 +1003,7 @@ class TestEnrichReportEdgeCases:
             ],
         }
 
-        with patch("cve_report_aggregator.core.orchestrator.create_enricher") as mock_create_enricher:
+        with patch("cve_report_aggregator.app.pipeline.create_enricher") as mock_create_enricher:
             from cve_report_aggregator.enhance.models import CVEEnricher
 
             mock_enricher = mock_create_enricher.return_value


### PR DESCRIPTION
## Summary

- Extracts a new `app/` composition layer that owns `run_aggregation`, `process_package_reports`, and `enrich_report`. Eliminates the only `core/ → enhance/` import in the codebase (previously at `core/orchestrator.py:18` and `:637`).
- Pins the layering invariant in CI via AST-based tests in `tests/unit/test_layering.py` so future contributors can't silently regress it.
- Documents the three-layer architecture (`core/` data ops, `enhance/` LLM providers, `app/` composition) in `docs/architecture.md` with a Mermaid dependency diagram.

## Why

`core/orchestrator.py` was the *only* file in `core/` importing from `enhance/`. That single import made the dependency graph a cycle on the package level and prevented `core/` from being usable without the enrichment subsystem. The fix isolates the composition into a new `app/` layer that sits above both `core/` and `enhance/` — neither of those packages imports the other anymore.

After the move:

- `core/` has zero outbound imports into `enhance/` (was 2)
- `enhance/` continues to import from `core/` (unchanged, expected direction)
- `app/` is the only place where the two layers compose

## What moved

| Function                                                                     | From                   | To                |
| ---------------------------------------------------------------------------- | ---------------------- | ----------------- |
| `run_aggregation`                                                            | `core/orchestrator.py` | `app/pipeline.py` |
| `process_package_reports`                                                    | `core/orchestrator.py` | `app/pipeline.py` |
| `enrich_report`                                                              | `core/orchestrator.py` | `app/pipeline.py` |
| `_count_eligible_cves`, `_build_enrichment_summary`, `_process_all_packages` | `core/orchestrator.py` | `app/pipeline.py` |

`AggregationResult` stays in `core/orchestrator.py` (pure data type, no enhance/ knowledge); `app/__init__.py` re-exports it for the CLI's public API.

## Commits

1. `test(layering)` — adds the architectural invariant tests (initially fails on `core → enhance`, drives the refactor).
1. `refactor(app)` — extracts the composition layer and updates consumers (`cli.py`, `core/__init__.py`, `tests/unit/test_orchestrator.py` imports + 4 mock paths).
1. `test(app)` — adds smoke tests for the new `app.pipeline` public API surface.
1. `docs(architecture)` — documents the three-layer architecture and references the invariant test.

Each commit is type-clean (`ty` passes) and the test suite is green at the tip.

## Test plan

- [x] Full unit test suite passes (647 tests, 1 warning)
- [x] `tests/unit/test_layering.py` enforces `core ↛ enhance` and `enhance ↛ app` via AST
- [x] AST verification: 0 `core → enhance` violations, 0 `core → app`, 0 `enhance → app`
- [x] `cve-report-aggregator --version` and `--help` smoke tests work
- [x] `ruff check .` clean across the entire repo
- [x] All 4 mock paths in `test_orchestrator.py` updated (`patch("...core.orchestrator.create_enricher")` → `patch("...app.pipeline.create_enricher")`); without this, `unittest.mock.patch` would silently target the old (now-empty) location and let the real enricher run
- [x] Reviewer: confirm no external callers of `cve_report_aggregator.core.run_aggregation` (the `core/__init__.py` re-export was dropped; verified empty in `src/` and `tests/` via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
